### PR TITLE
Fixing proxy always returning 200 OK

### DIFF
--- a/spark-ui-proxy.py
+++ b/spark-ui-proxy.py
@@ -37,7 +37,7 @@ SPARK_MASTER_HOST = ""
 class ProxyHandler(BaseHTTPRequestHandler):
     def do_GET(self):
         # Add an health checking endpoint.
-        if self.path in ("/healthz"):
+        if self.path in ["/healthz"]:
             self.send_response(code=200)
             self.send_header("Content-type", "text/plain")
             self.end_headers()
@@ -45,7 +45,7 @@ class ProxyHandler(BaseHTTPRequestHandler):
             return
 
         # redirect if we are hitting the home page
-        if self.path in ("", URL_PREFIX):
+        if self.path in ["", URL_PREFIX]:
             self.send_response(302)
             self.send_header("Location", URL_PREFIX + "proxy:" + SPARK_MASTER_HOST)
             self.end_headers()


### PR DESCRIPTION
Issue https://github.com/aseigneurin/spark-ui-proxy/issues/18 was introduced by https://github.com/aseigneurin/spark-ui-proxy/pull/16. We have to replace round brackets with square brackets, otherwise Python will search for strings and substrings in the specified sequence. Since the empty sting is substring of "/healthz", the proxy returns the health status instead of the Spark master home page. I have also fixed the subsequent if construct for more robustness.