### PR TITLE
Fix app links

### DIFF
--- a/spark-ui-proxy.py
+++ b/spark-ui-proxy.py
@@ -47,7 +47,7 @@ class ProxyHandler(BaseHTTPRequestHandler):
         # redirect if we are hitting the home page
         if self.path in ["", URL_PREFIX]:
             self.send_response(302)
-            self.send_header("Location", URL_PREFIX + "proxy:" + SPARK_MASTER_HOST)
+            self.send_header("Location", URL_PREFIX + "proxy:" + SPARK_MASTER_HOST + "/")
             self.end_headers()
             return
         self.proxyRequest(None)


### PR DESCRIPTION
App links fail on first load because the browser treats the initial redirect as a file and not a folder.
Links like `app?appId=....` should be appended to the proxy target, not replace it.
Otherwise a link from `http://proxy/proxy:master:8080` to `app?appId=...` will result in browsing `http://proxy/app?appId=...` instead of `http://proxy/proxy:master:8080/app?appId=....`